### PR TITLE
chore: add justfile and adapt readme

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2,11 +2,9 @@
 
 **CO2e** or **CO2eq** : Carbon dioxide equivalent (CO 2e or CO 2eq or CO 2-e) is calculated from GWP. For any gas, it is the mass of CO 2 that would warm the earth as much as the mass of that gas. (Wikipedia)
 
-**Category / Action / Option** : 3 level to determine CO2e emission factor. Exemple : Category Transportation / Action Train / Option TGV.  
-
+**Category / Action / Option** : 3 level to determine CO2e emission factor. Exemple : Category Transportation / Action Train / Option TGV.
 
 ## Users
-
 
 - DateTime **created_time** : Creation time (timestamp)
 - String **display_name** : Displayed name
@@ -23,6 +21,7 @@
 - DateTime (list) **connection_history** : (rafacto) list of last connexions
 
 ## Actions
+
 - string **uid** : UserId, users table
 - date **created_time** : Creation time (timestamp)
 - string **country** : FR
@@ -109,12 +108,10 @@
 - bool **onboardingUpdateTarget** : eventDeleteCount > 0
 - bool **onboardingUpdateTeam** : eventDeleteCount > 0
 
-
 ## Badges
 
 - **uid** : UserId, users table
 - bool **onboardingHowtoFinished** : Has finished howto
 - bool **onboardingAllChallenges** : Has finished all onboarding challenges
-
 
 ## Team Stats

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ gcloud config set project actions-dd2b5
 ## Refresh emulator (Firestore / Firebase) data
 
 You can run a bash script that will :
-- Generate fake data into firestore
-- Dump firestore database
-- Download dump into local firebase emulator
-- Launch firebase emulator
+  - Generate fake data into firestore
+  - Dump firestore database
+  - Download dump into local firebase emulator
+  - Launch firebase emulator
 
 Set permissions for the bash script :
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@
 - [Firebase CLI](https://firebase.google.com/docs/cli?hl=fr#install-cli-mac-linux)
 - [Google Cloud CLI](https://cloud.google.com/sdk/docs/install?hl=fr#deb)
 
+### Optionnal
+
+- [Just](https://github.com/casey/just): A `Makefile` alternative that run commands easily by creating a `justfile` at the root of the project. Natively installed on all OS where `sh` command is available.
+
 ## Install
+
+```bash
+just install
+```
+
+Or Manual installation:
 
 ```bash
 npm --prefix ./functions install ./functions
@@ -17,12 +27,16 @@ npm --prefix ./import install ./import
 
 ## Configure
 Download you service account json file from Google Firebase.  
+A file named `serviceAccountKey.json` should exist in `imports/` folder.
 
 ```bash
 # Copy account json file
 cp <yourFile> import/serviceAccountKey.json
+```
 
 # Configure Google Cloud CLI
+
+```bash
 gcloud auth login
 gcloud components update
 gcloud config set project actions-dd2b5
@@ -30,15 +44,50 @@ gcloud config set project actions-dd2b5
 
 💡 All files relative to backups will be stored inside the `./dumps/` folder.
 
-## Run
+## Refresh emulator (Firestore / Firebase) data
 
 You can run a bash script that will :
 - Generate fake data into firestore
 - Dump firestore database
 - Download dump into local firebase emulator
-- Lanuch firebase emulator
+- Launch firebase emulator
+
+Set permissions for the bash script :
 
 ```bash
 chmod +x ./refresh_emulator.bash
+```
+
+Then run it using:
+
+```bash
+just refresh
+```
+
+Or run it manually:
+
+```bash
 ./refresh_emulator.bash
 ```
+
+## Run the emulator
+
+```bash
+just dev
+```
+
+Or run it manually:
+
+```bash
+firebase emulators:start --import ./dumps
+```
+
+## Need help ? 
+
+> **Where are stored information about the data structure?**
+
+You can find the description of entities inside the [DATABASE.md](./DATABASE.md) file.
+
+> **I can't find or remember the command I want to run.**
+
+You can run the command `just help` to see the list of available commands in this project. Each command has an alternative manual way to do so.

--- a/justfile
+++ b/justfile
@@ -1,10 +1,8 @@
 set dotenv-load
 
-[private]
 default:
   @just help
 
-[private]
 help:
   @just --list
 
@@ -13,10 +11,10 @@ install:
   npm --prefix ./import install ./import
 
 refresh ARGS='':
-  ./refresh_emulator.bash
+  ./refresh_emulator.bash {{ARGS}}
 
 dev ARGS='':
-  firebase emulators:start --import ./dumps
+  firebase emulators:start --import ./dumps {{ARGS}}
 
 test ARGS='':
-  echo "Missing setup for unit testing."
+  echo "Missing setup for unit testing." {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,22 @@
+set dotenv-load
+
+[private]
+default:
+  @just help
+
+[private]
+help:
+  @just --list
+
+install:
+  npm --prefix ./functions install ./functions
+  npm --prefix ./import install ./import
+
+refresh ARGS='':
+  ./refresh_emulator.bash
+
+dev ARGS='':
+  firebase emulators:start --import ./dumps
+
+test ARGS='':
+  echo "Missing setup for unit testing."

--- a/refresh_emulator.bash
+++ b/refresh_emulator.bash
@@ -5,5 +5,3 @@ node import/generateData.js
 gsutil rm -r gs://actions-dd2b5.appspot.com/backups
 gcloud firestore export gs://actions-dd2b5.appspot.com/backups
 gsutil -m cp -r gs://actions-dd2b5.appspot.com/backups/* ./dumps/
-
-firebase emulators:start --import ./dumps


### PR DESCRIPTION
- Add `justfile` to simplify and synthetise commands.
- Modify the README accordingly.

How to test ?

Run :
- `just` and `just help`
- `just install`
- `just refresh`
- `just dev`

It should run the exact same things as before.
The README.md should reflect the changes about those commands. 